### PR TITLE
Add Visibility settings

### DIFF
--- a/src/srd_for_blender/SRDViewer/srdViewer.py
+++ b/src/srd_for_blender/SRDViewer/srdViewer.py
@@ -850,6 +850,15 @@ class srdViewer:
             else:
                 srdViewer.m_sourceOperator.report({"INFO"}, log)
 
+    m_selectedObjects: bool = False
+    m_visibleObjects: bool = False
+    m_activeCollection: bool = False
+
+    def setVisibility(selectedObjects, visibleObjects, activeCollection) -> None:
+        srdViewer.m_selectedObjects = selectedObjects
+        srdViewer.m_visibleObjects = visibleObjects
+        srdViewer.m_activeCollection = activeCollection
+
     def loadScene() -> None:
         srdViewer.setFbxPath()
         srdViewer.setFbxPresetPath()
@@ -861,9 +870,9 @@ class srdViewer:
                 filepath=fbxFullPathName,
                 check_existing=False,
                 filter_glob="*.fbx",
-                use_selection=False,
-                use_visible=False,
-                use_active_collection=False,
+                use_selection=srdViewer.m_selectedObjects,
+                use_visible=srdViewer.m_visibleObjects,
+                use_active_collection=srdViewer.m_activeCollection,
                 global_scale=1.0,
                 apply_unit_scale=True,
                 apply_scale_options="FBX_SCALE_ALL",

--- a/src/srd_for_blender/__init__.py
+++ b/src/srd_for_blender/__init__.py
@@ -82,6 +82,9 @@ class SRDPropertyIndex(enum.IntEnum):
     SpatialClippingSetting = enum.auto()
     ClipPlaneFront = enum.auto()
     ClipPlaneTop = enum.auto()
+    SelectedObjects = enum.auto()
+    VisibleObjects = enum.auto()
+    ActiveCollection = enum.auto()
 
 
 class SRDPropertyGroup(bpy.types.PropertyGroup):
@@ -143,6 +146,30 @@ class SRDPropertyGroup(bpy.types.PropertyGroup):
         default=True,
         update=lambda self, context: change_property_callback(
             self, context, SRDPropertyIndex.ClipPlaneTop
+        ),
+    )
+    SelectedObjects: bpy.props.BoolProperty(
+        name="",
+        description="",
+        default=False,
+        update=lambda self, context: change_property_callback(
+            self, context, SRDPropertyIndex.SelectedObjects
+        ),
+    )
+    VisibleObjects: bpy.props.BoolProperty(
+        name="",
+        description="",
+        default=False,
+        update=lambda self, context: change_property_callback(
+            self, context, SRDPropertyIndex.VisibleObjects
+        ),
+    )
+    ActiveCollection: bpy.props.BoolProperty(
+        name="",
+        description="",
+        default=False,
+        update=lambda self, context: change_property_callback(
+            self, context, SRDPropertyIndex.ActiveCollection
         ),
     )
 
@@ -303,6 +330,15 @@ class SRD_PT_Panel(bpy.types.Panel):
         row.prop(prop, "ClipPlaneTop", text="Top", translate=False)
         column.separator()
 
+        # Visibility setting
+        column.label(text="Visibility")
+        row = column.row(align=True)
+        row.label(text="Limit to:")
+        row.prop(prop, "SelectedObjects", text="Selected Objects", translate=False)
+        row.prop(prop, "VisibleObjects", text="Visible Objects", translate=False)
+        row.prop(prop, "ActiveCollection", text="Active Collection", translate=False)
+        column.separator()
+
 
 classes = [
     SRD_PT_Panel,
@@ -338,6 +374,11 @@ def change_property_callback(self, context, index: SRDPropertyIndex):
         front = data.ClipPlaneFront
         top = data.ClipPlaneTop
         srdViewer.setClippingPlane(front, top)
+    if index == SRDPropertyIndex.SelectedObjects or index == SRDPropertyIndex.VisibleObjects or index == SRDPropertyIndex.ActiveCollection:
+        selectedObjects = data.SelectedObjects
+        visibleObjects = data.VisibleObjects
+        activeCollection = data.ActiveCollection
+        srdViewer.setVisibility(selectedObjects, visibleObjects, activeCollection)
 
 
 def init_props():


### PR DESCRIPTION
This PR adds a feature that lets you control which 3D objects are visible. It allows you to hide objects you're not interested in and show only those you want to see.

Please note that you need to reload the scene for changes to take effect. Also, be careful to include the SRD camera objects in the selection, or the viewpoint may become incorrect.

![image](https://github.com/sony/SR-Display-Plugin-Preview-BL/assets/39654156/d15682f5-43cc-4343-932a-12b57d1fc110)
